### PR TITLE
StoreManagerのマイページにカレンダーの表示切り替えボタンを追加

### DIFF
--- a/app/controllers/store_manager/top_page_controller.rb
+++ b/app/controllers/store_manager/top_page_controller.rb
@@ -1,10 +1,38 @@
 class StoreManager::TopPageController < StoreManager::Base
+  include SmartYoyakuApi::Store
+  before_action :set_store_manager_and_store
 
-  def top
-    @store_manager = current_store_manager
+  def top   
     if @store_manager.order_plan.nil?
-      flash.now[:notice] = "現在ご利用中のプランは【無料プラン】となっており、#{@store_manager.store.store_name}様のページは非公開となっております。<br>
+      flash.now[:notice] = "現在ご利用中のプランは【無料プラン】となっており、#{@store.store_name}様のページは非公開となっております。<br>
                             「登録内容の編集」から有料プランをご契約いただきますとページが公開され、お客様からのご予約が可能となります。".html_safe
     end
   end
+
+  def update_calendar_status
+    set_status
+    # 予約カレンダーの表示を切り替える
+    @response = update_holiday_flag(@store, @status)
+    @store.update!(calendar_status: JSON.parse(@response)["calendar_status"])
+    flash.now[:notice] = "#{flash_message}"
+    render :top
+  end
+
+  private
+
+    def set_store_manager_and_store
+      @store_manager = current_store_manager
+      @store = @store_manager.store
+    end
+
+    # 現在公開中の場合「private(非公開)」、非公開中の場合「released(公開中)」をset
+    def set_status
+      @status =
+        @store.calendar_status == "released" ? "private" : "released"
+    end
+
+    # 更新後のcalendar_statusに合わせてメッセージを変更
+    def flash_message
+      @store.calendar_status == "released" ? "カレンダーを公開しました。" : "カレンダーを非公開にしました。"
+    end
 end

--- a/app/helpers/store_manager/plans_helper.rb
+++ b/app/helpers/store_manager/plans_helper.rb
@@ -1,2 +1,10 @@
 module StoreManager::PlansHelper
+
+  # @plans.firstの削除ボタンのみ非表示
+  def delete_plan_btn(plan, plans)
+    unless plan == plans.first
+      link_to "削除", store_manager_plan_path(plan), method: :delete,
+      data: { confirm: "#{plan.plan_name} を削除しますか？" } , class:"btn btn-outline-danger"
+    end
+  end
 end

--- a/app/helpers/store_manager/top_page_helper.rb
+++ b/app/helpers/store_manager/top_page_helper.rb
@@ -1,2 +1,15 @@
 module StoreManager::TopPageHelper
+
+  # カレンダーの表示／非表示切り替えボタン
+  def calendar_btn
+    if current_store_manager.order_plan.present?
+      link_to "予約カレンダーを#{calendar_btn_message}する", store_manager_update_calendar_status_path, method: :patch,
+      data: { confirm: "予約カレンダーを#{calendar_btn_message}します。" } , class: "btn btn-outline-secondary"
+    end
+  end
+
+  # 切り替えボタンのメッセージ
+  def calendar_btn_message
+    current_store_manager.store.calendar_status == "released" ? "非公開に" : "公開"
+  end
 end

--- a/app/lib/smart_yoyaku_api/store.rb
+++ b/app/lib/smart_yoyaku_api/store.rb
@@ -12,4 +12,14 @@ module SmartYoyakuApi::Store
     -H 'Content-Type:application/json' \
     -H 'Authorization: Bearer "#{current_store_manager.smart_token}"'`
   end
+
+  # 予約システムのカレンダーの表示／非表示を切り替える
+  def update_holiday_flag(store, status)
+    url = reserve_app_url + "api/v1/calendars/update_holiday_flag"
+    `curl -v -X PATCH "#{url}" \
+    -d '{"calendar":{"public_id":"#{store.calendar_id}","status":"#{status}"}}' \
+    -H 'Accept: application/json' \
+    -H 'Content-Type:application/json' \
+    -H 'Authorization: Bearer "#{current_store_manager.smart_token}"'`
+  end
 end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -10,6 +10,7 @@ class Store < ApplicationRecord
   validates :adress, length: { minimum: 5 }, allow_blank: true
   validates :store_phonenumber, length: { minimum: 10 }, allow_blank: true
   validates :store_description, length: { minimum: 10 }, allow_blank: true
+  enum calendar_status: { "released": 0, "private": 1 }, _prefix: true
 
   scope :active, -> { includes(:store_manager).where.not(store_managers: {order_plan: nil}) }
 end

--- a/app/views/store_manager/plans/index.html.erb
+++ b/app/views/store_manager/plans/index.html.erb
@@ -15,8 +15,7 @@
                   <td class="align-middle"><%= link_to plan.plan_name.truncate(15), store_manager_plan_path(plan)  %></td>
                   <td class="text-right">
                     <%= link_to "編集", edit_store_manager_plan_path(plan), class:"btn btn-outline-primary" %>
-                    <%= link_to "削除", store_manager_plan_path(plan), method: :delete,
-                    data: { confirm: "#{plan.plan_name} を削除しますか？" } , class:"btn btn-outline-danger" %>
+                    <%= delete_plan_btn(plan, @plans) %>
                   </td>
                 </tr>
               </tbody>

--- a/app/views/store_manager/top_page/top.html.erb
+++ b/app/views/store_manager/top_page/top.html.erb
@@ -5,6 +5,9 @@
   <div class="text_left">
     <h1 class="top_space">マイページトップ</h1>
   </div>
+  <div class="text-right mb-4">
+    <%= calendar_btn %>  
+  </div>
   <div class="mypage_space">
     <h2 class="headline_space text_left">管理者からの連絡</h2>
     <p class="text_space_15 text_left">メッセージはありません。</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,7 @@ Rails.application.routes.draw do
   # Store_manager↓========================================================================================
     namespace :store_manager do
       get "/:id/top", to: 'top_page#top'
+      patch "update_calendar_status", to: 'top_page#update_calendar_status'
       resources :store
       resources :masseurs, except: :show
       resources :plans

--- a/db/migrate/20200709104918_add_calendar_status_to_stores.rb
+++ b/db/migrate/20200709104918_add_calendar_status_to_stores.rb
@@ -1,0 +1,5 @@
+class AddCalendarStatusToStores < ActiveRecord::Migration[6.0]
+  def change
+    add_column :stores, :calendar_status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_05_082752) do
+ActiveRecord::Schema.define(version: 2020_07_09_104918) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -151,7 +151,8 @@ ActiveRecord::Schema.define(version: 2020_07_05_082752) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "calendar_id"
-    t.bigint "calendar_secret_id"
+    t.integer "calendar_secret_id"
+    t.integer "calendar_status", default: 0
     t.index ["store_manager_id"], name: "index_stores_on_store_manager_id"
   end
 


### PR DESCRIPTION
●StoreManagerのマイページにカレンダーボタンを設置
●Planが0になると予約システムでエラーになるので、プランが必ず一つ残るようにPlan一覧ページ削除ボタンを調整
●Storesテーブルにcalendar_statusカラムを追加