### PR TITLE
full-calendarでの表示時間の修正

### DIFF
--- a/app/views/store_managers/registrations/index.json.jbuilder
+++ b/app/views/store_managers/registrations/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array!(@api) do |api|
   json.title api["store_member"]["name"] + "様 :" + api["task_course"]["title"]
-  json.start Time.at(api["start_at"] + 32400).strftime("%F %T")
-  json.end Time.at(api["end_at"] + 32400).strftime("%F %T")
+  json.start Time.at(api["start_at"]).strftime("%F %T")
+  json.end Time.at(api["end_at"]).strftime("%F %T")
   json.name api["store_member"]["name"]
   json.email api["store_member"]["email"]
   json.address api["store_member"]["address"]

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,7 @@ module SmartReservation
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.0
     config.time_zone = 'Asia/Tokyo'
+    config.active_record.default_timezone = :local
     config.i18n.default_locale = :ja
     config.autoload_paths += Dir[Rails.root.join('app', 'uploaders')]
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]


### PR DESCRIPTION
●カレンダーの表示時間を日本時間に合わせるために、jsonを取得変換している部分を修正させていただきました
●今回の修正に直接関係はありませんでしたが、DBに書き込む際の時間設定もJSTになるよう追加しました