### PR TITLE
環境変数の設定とplan:createの修正

### DIFF
--- a/app/controllers/store_manager/plans_controller.rb
+++ b/app/controllers/store_manager/plans_controller.rb
@@ -16,11 +16,10 @@ class StoreManager::PlansController < StoreManager::Base
   def create
     @plan = current_store_manager.store.plans.build(plan_params)
     ActiveRecord::Base.transaction do
-      response = task_course_create(@plan)
-      response_parse = JSON.parse(response)
-      @plan.course_id = response_parse['data']['id']
-      @plan.save
-      if @plan.persisted?
+      if @plan.save
+        response = task_course_create(@plan)
+        response_parse = JSON.parse(response)
+        @plan.update!(course_id: response_parse['data']['id'])
         flash[:success] = '新規作成に成功しました。'
         redirect_to store_manager_plans_url
       else

--- a/app/controllers/store_managers/registrations_controller.rb
+++ b/app/controllers/store_managers/registrations_controller.rb
@@ -18,15 +18,15 @@ class StoreManagers::RegistrationsController < Devise::RegistrationsController
     # 「ご契約中のシステムプランの確認」の遷移先
     @order_plan_url = 
       if current_store_manager.order_plan.nil?
-        reserve_app_url + "pay/choice_plan"
+        reserve_app_url + "/pay/choice_plan"
       else  
-        reserve_app_url + "order_plan/#{current_store_manager.order_plan}"
+        reserve_app_url + "/order_plan/#{current_store_manager.order_plan}"
       end
   end
 
   # 予約の確認
   def index
-    url = reserve_app_url + "api/v1/tasks"
+    url = reserve_app_url + "/api/v1/tasks"
     uri = `curl -v -X GET "#{url}" \
     -H 'Authorization: Bearer "#{current_store_manager.smart_token}"'`
     @api = JSON.parse(uri)["tasks"]

--- a/app/lib/smart_yoyaku_api/calendar.rb
+++ b/app/lib/smart_yoyaku_api/calendar.rb
@@ -5,7 +5,7 @@ module SmartYoyakuApi::Calendar
 
   # 予約システム側でCalendarの更新を行う    
   def update_calendar(store)
-    url = reserve_app_url + "api/v1/calendars"
+    url = reserve_app_url + "/api/v1/calendars"
     `curl -v -X PATCH "#{url}" \
     -d '{"calendar":{"calendar_name":"#{store.store_name}","address":"#{store.adress}","phone":"#{store.store_phonenumber}","public_id":"#{store.calendar_id}"}}' \
     -H 'Accept: application/json' \
@@ -15,7 +15,7 @@ module SmartYoyakuApi::Calendar
 
   # 予約システムのカレンダーの表示／非表示を切り替える
   def update_holiday_flag(store, status)
-    url = reserve_app_url + "api/v1/calendars/update_holiday_flag"
+    url = reserve_app_url + "/api/v1/calendars/update_holiday_flag"
     `curl -v -X PATCH "#{url}" \
     -d '{"calendar":{"public_id":"#{store.calendar_id}","status":"#{status}"}}' \
     -H 'Accept: application/json' \

--- a/app/lib/smart_yoyaku_api/staff.rb
+++ b/app/lib/smart_yoyaku_api/staff.rb
@@ -5,7 +5,7 @@ module SmartYoyakuApi::Staff
 
   # 予約システム側のStaff情報を更新    
   def update_staff(masseur)
-    url = reserve_app_url + "api/v1/staffs/#{masseur.staff_id}"
+    url = reserve_app_url + "/api/v1/staffs/#{masseur.staff_id}"
     `curl -v -X PATCH "#{url}" \
     -d '{"staff":{"name":"#{masseur.masseur_name}","email":"#{masseur.email}","password":"#{params[:masseur][:password]}","password_confirmation":"#{params[:masseur][:password_confirmation]}"}}' \
     -H 'Accept: application/json' \

--- a/app/lib/smart_yoyaku_api/task_course.rb
+++ b/app/lib/smart_yoyaku_api/task_course.rb
@@ -4,7 +4,7 @@ module SmartYoyakuApi::TaskCourse
   private
 
   def task_course_create(plan)
-    url = reserve_app_url + "api/v1/task_courses"
+    url = reserve_app_url + "/api/v1/task_courses"
     `curl -v POST "#{url}" \
     -d '{"task_course":{"title":"#{plan.plan_name}","description":"#{plan.plan_content.gsub(/(\r\n|\r|\n)/, "")}","course_time":"#{plan.plan_time}","charge":"#{plan.plan_price}","calendar_id":"#{plan.store.calendar_secret_id}"}}' \
     -H 'Accept: application/json' \
@@ -13,7 +13,7 @@ module SmartYoyakuApi::TaskCourse
   end
 
   def task_course_update(plan)
-    url = reserve_app_url + "api/v1/task_courses/#{plan.course_id}"
+    url = reserve_app_url + "/api/v1/task_courses/#{plan.course_id}"
     `curl -v -X PATCH "#{url}" \
     -d '{"task_course":{"title":"#{plan.plan_name}","description":"#{plan.plan_content.gsub(/(\r\n|\r|\n)/, "")}","course_time":"#{plan.plan_time}","charge":"#{plan.plan_price}","calendar_id":"#{plan.store.calendar_secret_id}"}}' \
     -H 'Accept: application/json' \
@@ -22,7 +22,7 @@ module SmartYoyakuApi::TaskCourse
   end
 
   def task_course_delete(plan)
-    url = reserve_app_url + "api/v1/task_courses/#{plan.course_id}"
+    url = reserve_app_url + "/api/v1/task_courses/#{plan.course_id}"
     `curl -v -X DELETE "#{url}" \
     -H 'Authorization: Bearer "#{current_store_manager.smart_token}"'`
   end

--- a/app/lib/smart_yoyaku_api/user.rb
+++ b/app/lib/smart_yoyaku_api/user.rb
@@ -2,14 +2,14 @@ module SmartYoyakuApi::User
 
   private
  
-  # 開発中は各自中身を書き換えて使用してください
+  # 開発中は各自「.env」の環境変数を自分の開発環境に合わせて書き換えてください
   def reserve_app_url
-    Rails.env.development? ? "http://localhost:3000/" : "https://smartyoyaku-staging.herokuapp.com/"
+    Rails.env.development? ? ENV['DEVELOPMENT_SMART_YOYAKU_URL'] : ENV['PRODUCTION_SMART_YOYAKU_URL']
   end
   
   # 予約システム側でUserの登録を行う
   def create_user(store_manager, store, plan)
-    url = reserve_app_url + "api/v1/users"
+    url = reserve_app_url + "/api/v1/users"
     `curl -v POST "#{url}" \
     -d '{"user":{"name":"#{store_manager.name}","email":"#{store_manager.email}","password":"#{store_manager.password}"},\
     "calendar":{"calendar_name":"#{store.store_name}","address":"#{store.adress}","phone":"#{store.store_phonenumber}"},\
@@ -20,7 +20,7 @@ module SmartYoyakuApi::User
 
   # 予約システム側でUserの更新を行う
   def update_user(name, email, password)
-    url = reserve_app_url + "api/v1/users"
+    url = reserve_app_url + "/api/v1/users"
     `curl -v -X PATCH "#{url}" \
     -d '{"user":{"name":"#{name}","email":"#{email}","password":"#{password}","password_confirmation":"#{password}"}}' \
     -H 'Accept: application/json' \

--- a/app/views/user/top/details.html.erb
+++ b/app/views/user/top/details.html.erb
@@ -85,7 +85,7 @@
               <!--<span>首・肩集中コース</span>
               <span>〇〇円(税込)</span>-->
             </p>
-            <a><%= link_to "予約可能時間の確認", "#{@reserve_app_url}calendars/#{@store.calendar_id}/tasks", class:"btn btn-warning btn-lg"%></a>
+            <a><%= link_to "予約可能時間の確認", "#{@reserve_app_url}/calendars/#{@store.calendar_id}/tasks", class:"btn btn-warning btn-lg"%></a>
           </div>
         </div>
       </div>
@@ -123,7 +123,7 @@
               <td><%= plan.plan_name %></td>
               <td><%= plan.plan_time %>分</td>
               <td class="js-price"><%= plan.plan_price %>円(税込)</td>
-              <td><%= link_to "プランを予約する", "#{@reserve_app_url}calendars/#{@store.calendar_id}/tasks?course_id=#{plan.course_id}", class:"btn btn-success" %></td>
+              <td><%= link_to "プランを予約する", "#{@reserve_app_url}/calendars/#{@store.calendar_id}/tasks?course_id=#{plan.course_id}", class:"btn btn-success" %></td>
             </tr>
             <% end %>
           </tbody>


### PR DESCRIPTION
●予約システムのAPIのURL部分を環境変数で置き換えました。
☆こちらのbranchでは(そしてこちらのbranchをmerge後は).envに

DEVELOPMENT_SMART_YOYAKU_URL = http://localhost:3000
PRODUCTION_SMART_YOYAKU_URL = https://smartyoyaku-staging.herokuapp.com

の追記が必要になります。
APIに関わるURLを.envで簡単に管理できるようにしました。

●planのcreateの際、invalidの場合ポータルサイトではrender new となるが
予約システムではtask_courseが作成されていたので、
予約システムでも作成されないようにplan_controllerのcreateアクションを修正しました